### PR TITLE
fix: remove broken junction in mirador directory

### DIFF
--- a/mirador/mirador
+++ b/mirador/mirador
@@ -1,1 +1,0 @@
-/app/mirador


### PR DESCRIPTION
- Removes circular/broken JUNCTION at mirador/mirador

- This junction was causing Docker builds to fail with 'invalid file request' error

- Resolves issue #23 where docker build -f Dockerfile.dev would fail